### PR TITLE
Remove NativeVotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The changes that have been merged into this branch compared to powerlord's versi
 - Fixed Russian translations.
 - Log steamid when someone nominates a map.
 - Ceil instead of Floor votes needed.
+- Remove NativeVotes include.
 
 ## Credits
 


### PR DESCRIPTION
NativeVotes does not seem to work anymore after various updates. It does
not seem to be needed in CSGO, which is the game I am mainly building
this for, so lets get rid of it and see what happens.

Additionally it makes the whole logic with menus a lot simpler, since
there is no longer duplicates around everything.