### PR TITLE
Replace emitsoundany with using sdktools instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The changes that have been merged into this branch compared to powerlord's versi
 - Log steamid when someone nominates a map.
 - Ceil instead of Floor votes needed.
 - Remove NativeVotes include.
+- Remove emitsoundany include.
 
 ## Credits
 

--- a/addons/sourcemod/scripting/mapchooser_extended_sounds.sp
+++ b/addons/sourcemod/scripting/mapchooser_extended_sounds.sp
@@ -38,7 +38,6 @@
 #include <mapchooser>
 #include "include/mapchooser_extended"
 #include <sdktools>
-#include <emitsoundany>
 
 #define VERSION "1.10.3"
 
@@ -259,7 +258,7 @@ public OnMapVoteWarningTick(time)
 				}
 				else
 				{
-					EmitSoundToAllAny(soundData[SoundStore_Value]);
+					EmitSoundToAll(soundData[SoundStore_Value]);
 				}
 			}
 		}
@@ -314,7 +313,7 @@ PlaySound(SoundEvent:event)
 				}
 				else
 				{
-					EmitSoundToAllAny(soundData[SoundStore_Value]);
+					EmitSoundToAll(soundData[SoundStore_Value]);
 				}
 			}
 		}
@@ -568,11 +567,11 @@ CacheSound(soundData[SoundStore])
 {
 	if (soundData[SoundStore_Type] == SoundType_Builtin)
 	{
-		PrecacheSoundAny(soundData[SoundStore_Value]);
+		PrecacheSound(soundData[SoundStore_Value], true);
 	}
 	else if (soundData[SoundStore_Type] == SoundType_Sound)
 	{
-		if (PrecacheSoundAny(soundData[SoundStore_Value]))
+		if (PrecacheSound(soundData[SoundStore_Value], true))
 		{
 			decl String:downloadLocation[PLATFORM_MAX_PATH];
 			Format(downloadLocation, sizeof(downloadLocation), "sound/%s", soundData[SoundStore_Value]);


### PR DESCRIPTION
Apparently after the 2018 csgo update, the emitsoundany include is no
longer needed. So instaed of adding that, we are just using what
Sourcemod provides.

Also setting precache to true on the sounds, so that there are no
unpleasant lags or anything when they are supposed to be used.

Completely untested changes, but it compiles!