### PR TITLE
Remove unneeded GetEngineVersionCompat stock

### DIFF
--- a/addons/sourcemod/scripting/mapchooser_extended.sp
+++ b/addons/sourcemod/scripting/mapchooser_extended.sp
@@ -273,7 +273,7 @@ public OnPluginStart()
 	g_Cvar_Maxrounds = FindConVar("mp_maxrounds");
 	g_Cvar_Fraglimit = FindConVar("mp_fraglimit");
 
-	new EngineVersion:version = GetEngineVersionCompat();
+	new EngineVersion:version = GetEngineVersion();
 
 	decl String:mapListPath[PLATFORM_MAX_PATH];
 
@@ -384,8 +384,6 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	}
 
 	RegPluginLibrary("mapchooser");
-
-	MarkNativeAsOptional("GetEngineVersion");
 
 	CreateNative("NominateMap", Native_NominateMap);
 	CreateNative("RemoveNominationByMap", Native_RemoveNominationByMap);
@@ -2104,112 +2102,6 @@ stock AddExtendToMenu(Handle:menu, MapChange:when)
 	{
 		AddMenuItem(menu, VOTE_EXTEND, "Extend Map");
 	}
-}
-
-// Using this stock REQUIRES you to add the following to AskPluginLoad2:
-// MarkNativeAsOptional("GetEngineVersion");
-stock EngineVersion:GetEngineVersionCompat()
-{
-	new EngineVersion:version;
-	if (GetFeatureStatus(FeatureType_Native, "GetEngineVersion") != FeatureStatus_Available)
-	{
-		new sdkVersion = GuessSDKVersion();
-		switch (sdkVersion)
-		{
-			case SOURCE_SDK_ORIGINAL:
-			{
-				version = Engine_Original;
-			}
-
-			case SOURCE_SDK_DARKMESSIAH:
-			{
-				version = Engine_DarkMessiah;
-			}
-
-			case SOURCE_SDK_EPISODE1:
-			{
-				version = Engine_SourceSDK2006;
-			}
-
-			case SOURCE_SDK_EPISODE2:
-			{
-				version = Engine_SourceSDK2007;
-			}
-
-			case SOURCE_SDK_BLOODYGOODTIME:
-			{
-				version = Engine_BloodyGoodTime;
-			}
-
-			case SOURCE_SDK_EYE:
-			{
-				version = Engine_EYE;
-			}
-
-			case SOURCE_SDK_CSS:
-			{
-				version = Engine_CSS;
-			}
-
-			case SOURCE_SDK_EPISODE2VALVE:
-			{
-				decl String:gameFolder[PLATFORM_MAX_PATH];
-				GetGameFolderName(gameFolder, PLATFORM_MAX_PATH);
-				if (StrEqual(gameFolder, "dod", false))
-				{
-					version = Engine_DODS;
-				}
-				else if (StrEqual(gameFolder, "hl2mp", false))
-				{
-					version = Engine_HL2DM;
-				}
-				else
-				{
-					version = Engine_TF2;
-				}
-			}
-
-			case SOURCE_SDK_LEFT4DEAD:
-			{
-				version = Engine_Left4Dead;
-			}
-
-			case SOURCE_SDK_LEFT4DEAD2:
-			{
-				decl String:gameFolder[PLATFORM_MAX_PATH];
-				GetGameFolderName(gameFolder, PLATFORM_MAX_PATH);
-				if (StrEqual(gameFolder, "nd", false))
-				{
-					version = Engine_NuclearDawn;
-				}
-				else
-				{
-					version = Engine_Left4Dead2;
-				}
-			}
-
-			case SOURCE_SDK_ALIENSWARM:
-			{
-				version = Engine_AlienSwarm;
-			}
-
-			case SOURCE_SDK_CSGO:
-			{
-				version = Engine_CSGO;
-			}
-
-			default:
-			{
-				version = Engine_Unknown;
-			}
-		}
-	}
-	else
-	{
-		version = GetEngineVersion();
-	}
-
-	return version;
 }
 
 GetVoteSize()


### PR DESCRIPTION
The GetEngineVersionCompat stock was created to help with compatibility
in Sourcemod 1.5 and 1.6. There is no need to use this anymore, as
GetEngineVersion exists now provided by Sourcemod.

Therefor there is no need to mark GetEngineVersion as optional anymore
either.